### PR TITLE
Added protocol detection/matching for PubNub calls

### DIFF
--- a/web/resources/js/dashboard.js
+++ b/web/resources/js/dashboard.js
@@ -42,7 +42,8 @@ app.controller('DashboardCtrl', ['$rootScope', '$scope', '$http', 'PubNub', '$in
 
     $scope.PubNubInit = function () {
         PubNub.init({
-            subscribe_key: $scope.params.PubNub.SubscribeKey
+            subscribe_key: $scope.params.PubNub.SubscribeKey,
+            ssl: (('https:' == document.location.protocol) ? true : false)
         });
 
         $scope.PubNubSubscribe();


### PR DESCRIPTION
The dashboard will fail to load in chrome when served up via HTTPS. Chrome blocks the calls to Pubnub as insecure, since they're being made via HTTP within and HTTPS site. The messages displayed to the chrome console are along the lines of:

xhrExtension.js:2 XMLHttpRequest cannot load http://XXXXXXXXXX.pubnub.com/time/0?uuid=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX&pnsdk=PubNub-JS-Web%2F3.7.23. Failed to start loading.
(anonymous) @ xhrExtension.js:2
P @ pubnub.min.js:3
j @ pubnub.min.js:3
time @ pubnub.min.js:3
(anonymous) @ pubnub.min.js:3

xhrExtension.js:2 Mixed Content: The page at 'https://WEBSERVER/#/dashboard' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://XXXXXXXXXX.pubnub.com/time/0?uuid=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX&pnsdk=PubNub-JS-Web%2F3.7.23'. This request has been blocked; the content must be served over HTTPS.
(anonymous) @ xhrExtension.js:2
P @ pubnub.min.js:3
j @ pubnub.min.js:3
time @ pubnub.min.js:3
(anonymous) @ pubnub.min.js:3

Applying the Pubnub recommend fix outlined in this link fixed our issue... and now lets us serve up the dashboard correctly via either HTTP or HTTPS:
https://support.pubnub.com/support/discussions/topics/14000006213
