### PR TITLE
Fix creation of alerts at start and Timeout on lambda for null event

### DIFF
--- a/lambda/index.js
+++ b/lambda/index.js
@@ -33,7 +33,7 @@ function getReqOpts(opt, queryParams) {
         path: url,
         method: opt.method,
         headers: {
-            'Authorization': 'GenieKey ' + event.apiKey
+            'Authorization': 'GenieKey ' + queryParams.apiKey
         }
     };
 }
@@ -79,6 +79,9 @@ function publishEventOnPubnub(event, context) {
 }
 
 exports.handler = function(event, context) {
+    if (Object.keys(event).length === 0){
+        context.done();
+    }
     if (event.lambdaOperation && event.apiKey) {
         switch(event.lambdaOperation) {
             case "Alerts":

--- a/web/resources/js/dashboard.js
+++ b/web/resources/js/dashboard.js
@@ -112,15 +112,16 @@ app.controller('DashboardCtrl', ['$rootScope', '$scope', '$http', 'PubNub', '$in
         var dataObj = {
             lambdaOperation: $scope.params.api.lambda_operations.alerts.operation,
             apiKey: $scope.params.api.key,
-            status: $scope.params.api.lambda_operations.alerts.status,
-            limit: $scope.params.api.lambda_operations.alerts.limit
+            query: "status%3A" + $scope.params.api.lambda_operations.alerts.status,
+            limit: $scope.params.api.lambda_operations.alerts.limit,
+            sort: "createdAt"
         };
 
         var res = $scope.makeApiRequest(dataObj);
 
         res.success(function (data, status, headers, config) {
-            if (angular.isDefined(data.alerts)) {
-                angular.forEach(data.alerts, function (alert, index) {
+            if (angular.isDefined(data.data)) {
+                angular.forEach(data.data, function (alert, index) {
                     $scope.createAlert(alert);
                 });
             } else {
@@ -262,8 +263,8 @@ app.controller('DashboardCtrl', ['$rootScope', '$scope', '$http', 'PubNub', '$in
         alert.tagIndex = 0;
 
         if (angular.isUndefined(notification)) {
-            alert.createdAt = Math.floor(alert.createdAt / 1000000); // TODO WebHook createdAt fix
-            alert.updatedAt = Math.floor(alert.updatedAt / 1000000); // TODO WebHook createdAt fix
+            alert.createdAt = Date.parse(alert.createdAt);
+            alert.updatedAt = Date.parse(alert.updatedAt);
         }
 
         $scope.updateAlertsData(alert);


### PR DESCRIPTION
With the new version of the opsgenie api the creation of open alerts at start is now broken, I made the necessary changes for it to work.

Fixed timeout error on lambda when a null request is sent.